### PR TITLE
Disable minAvailable setting in Pod Disruption Budget configuration

### DIFF
--- a/charts/dotnet/values.yaml
+++ b/charts/dotnet/values.yaml
@@ -150,7 +150,7 @@ autoscaling:
 # @section -- PDB Settings
 pdb:
   create: false
-  minAvailable: 1
+  # minAvailable: 1
   # maxUnavailable: 1
 
 # -- Node selector settings


### PR DESCRIPTION
The issue occurred because Helm was merging the default `minAvailable` from the chart with the `maxUnavailable` from overrides, violating the Kubernetes rule that these fields are mutually exclusive.

Here is an error when trying to specify only `maxUnavailable` in overrides:
```
Error: UPGRADE FAILED: failed to create resource: PodDisruptionBudget.policy "worker-api" is invalid: spec: Invalid value: policy.PodDisruptionBudgetSpec{MinAvailable:(*intstr.IntOrString)(0xc01df6a540), Selector:(*v1.LabelSelector)(0xc01df6a560), MaxUnavailable:(*intstr.IntOrString)(0xc01df6a520), UnhealthyPodEvictionPolicy:(*policy.UnhealthyPodEvictionPolicyType)(nil)}: minAvailable and maxUnavailable cannot be both set
```

By commenting out the default value in the main `values.yaml` file, it was ensured that only one violation strategy would be reflected in the final manifest, which successfully resolved the validation conflict.