### PR TITLE
updated the external-secrets apiVersion

### DIFF
--- a/charts/fastapi/templates/secrets.yaml
+++ b/charts/fastapi/templates/secrets.yaml
@@ -10,7 +10,7 @@ data:
 
 {{- if .Values.fastapi.env.envFromSecretsManager.enabled }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "fastapi.fullname" . }}-env-ext-secrets


### PR DESCRIPTION
This pull request makes a minor update to the `charts/fastapi/templates/secrets.yaml` file by changing the API version for `ExternalSecret` resources to ensure compatibility with the current version of the external-secrets API.