### PR TITLE
Feature/update external secrets api version

### DIFF
--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cronjobs/templates/secrets.yaml
+++ b/charts/cronjobs/templates/secrets.yaml
@@ -10,7 +10,7 @@ data:
 
 {{- if .Values.env.envFromSecretsManager.enabled }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "cronjobs.fullname" . }}-env-ext-secrets

--- a/charts/django/Chart.yaml
+++ b/charts/django/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/django/templates/migrations/migrations-secrets.yaml
+++ b/charts/django/templates/migrations/migrations-secrets.yaml
@@ -15,7 +15,7 @@ data:
 
 {{- if .Values.django.env.envFromSecretsManager.enabled }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "django.fullname" . }}-env-migration-ext-secrets

--- a/charts/django/templates/secrets.yaml
+++ b/charts/django/templates/secrets.yaml
@@ -10,7 +10,7 @@ data:
 
 {{- if .Values.django.env.envFromSecretsManager.enabled }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "django.fullname" . }}-env-ext-secrets

--- a/charts/nextjs/Chart.yaml
+++ b/charts/nextjs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nextjs/templates/secrets.yaml
+++ b/charts/nextjs/templates/secrets.yaml
@@ -10,7 +10,7 @@ data:
 
 {{- if .Values.nextjs.env.envFromSecretsManager.enabled }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "nextjs.fullname" . }}-env-ext-secrets


### PR DESCRIPTION
This change updates the API version for ExternalSecret resources from v1beta1 to v1 to ensure compatibility with the current version of the external-secrets API. The chart version has been incremented to 0.2.0.